### PR TITLE
Fix bug that random color is duplicated.

### DIFF
--- a/Assets/Scripts/StageContainer.cs
+++ b/Assets/Scripts/StageContainer.cs
@@ -38,7 +38,7 @@ public class StageContainer : MonoBehaviour {
 	private void createStage() {
 		Block destination = BlockFactory.generate (Depth.DESTINATION_DEPTH);
 		Block source = BlockFactory.generate (Depth.SOURCE_DEPTH, destination.polymino);
-		var sampleColor = colors.Sample (2);
+		var sampleColor = colors.Sample (2).ToList();
 		destination.dye(sampleColor.First());
 		source.dye(sampleColor.Last());
 		


### PR DESCRIPTION
Sample function return query.
So if use first or last to it, it makes two random sequences.
So two random sequences can have duplicated color.

Use ToList to run query before use it.
